### PR TITLE
Fix qt widgets build

### DIFF
--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
@@ -51,13 +51,14 @@ constexpr int IndicatorUnknown = IndicatorInput + 3;
 using namespace Scintilla;
 using namespace Scintilla::Internal;
 
-ScintillaEditBase::ScintillaEditBase(QQuickItem/*QWidget*/ *parent)
 #ifdef PLAT_QT_QML
+ScintillaEditBase::ScintillaEditBase(QQuickItem/*QWidget*/ *parent)
 : QQuickPaintedItem(parent)
+, enableUpdateFlag(true), logicalWidth(0), logicalHeight(0)
 #else
+ScintillaEditBase::ScintillaEditBase(QWidget *parent)
 : QAbstractScrollArea(parent)
 #endif
-, enableUpdateFlag(true), logicalWidth(0), logicalHeight(0)
 #ifdef PLAT_QT_QML
 , dataInputMethodHints(Qt::ImhNone)
 //, aLongTouchTimer(this)

--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
@@ -116,7 +116,6 @@ HEADERS  += \
     ../../src/CallTip.h \
     ../../src/AutoComplete.h \
     ../../include/Scintilla.h \
-    ../../include/Platform.h \
     ../../include/ILexer.h \
 
 OTHER_FILES +=

--- a/scintilla/qt/ScintillaEditBase/ScintillaQt.cpp
+++ b/scintilla/qt/ScintillaEditBase/ScintillaQt.cpp
@@ -906,7 +906,7 @@ void ScintillaQt::PartialPaint(const PRectangle &rect)
 		scrollArea->update();
 	}
 
-	paintState = notPainting;
+	paintState = PaintState::notPainting;
 #else
 	PartialPaintQml(rect, nullptr);
 #endif	

--- a/scintilla/src/Editor.cxx
+++ b/scintilla/src/Editor.cxx
@@ -5751,7 +5751,13 @@ std::unique_ptr<Surface> Editor::CreateMeasurementSurface(Scintilla::Internal::P
 		return {};
 	}
 	std::unique_ptr<Surface> surf = Surface::Allocate(technology);
+
+#ifdef PLAT_QT_QML
     surf->Init(/*wMain.GetID()*/true, pid);
+#else
+	surf->Init(wMain.GetID());
+#endif
+
 	surf->SetMode(CurrentSurfaceMode());
 	return surf;
 }

--- a/scintilla/src/Editor.h
+++ b/scintilla/src/Editor.h
@@ -698,7 +698,9 @@ private:
 public:
     AutoSurface(const Editor *ed, Scintilla::Internal::PainterID pid = nullptr, int _technology = -1) :
         surf(ed->CreateMeasurementSurface(pid, _technology))  {
+#ifdef PLAT_QT_QML
         surf->Init(false, pid);
+#endif
     }
     AutoSurface(SurfaceID sid, Editor *ed, std::optional<Scintilla::Technology> technology = {}) :
 		surf(ed->CreateDrawingSurface(sid, technology)) {

--- a/scintilla/src/Platform.h
+++ b/scintilla/src/Platform.h
@@ -47,10 +47,12 @@
 #define PLAT_HAIKU 1
 
 #elif defined(SCINTILLA_QT)
+#undef PLAT_QT_QML
 #undef PLAT_QT
 #define PLAT_QT 1
 
 #elif defined(SCINTILLA_QT_QML)
+#undef PLAT_QT
 #undef PLAT_QT_QML
 #define PLAT_QT_QML 1
 


### PR DESCRIPTION
Hello,

I am trying to get QuickScintilla to work with both QML/Quick and Qt Widgets.
QuickScintilla compiles/works fine for QML/Quick but not for Qt Widgets. I saw that I can set "SCINTILLA_QT" if I want to compile QuickScintilla for Qt Widgets.
When I did that, I got a lot of errors in Qt Creator (during compilation). I have adjusted the code in this PR so that these errors no longer occur.
I had some additional errors that occurred during runtime. I fixed those as well.
Now if you set SCINTILLA_QT in ScintillaEditBase.pro instead of SCINTILLA_QT_QML like this ...:

    DEFINES += SCINTILLA_QT=1 MAKING_LIBRARY=1 _CRT_SECURE_NO_DEPRECATE=1

... you can compile (and later use) the library for Qt Widgets as well.

I also created a small test project that you can find here: https://github.com/AdMayr/quick-scintilla-test-minimal/tree/main/quick-scintilla-test-minimal
Works on Windows 10 with Qt 5.14.0.