### PR TITLE
Scrolling with the mouse wheel has no effect when using QML/Quick and Qt 6

### DIFF
--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
@@ -342,9 +342,7 @@ void ScintillaEditBase::wheelEvent(QWheelEvent *event)
 				}
 				QQuickPaintedItem::wheelEvent(event);
 
-#ifdef PLAT_QT_QML
                 update();
-#endif
 #else
 				QAbstractScrollArea::wheelEvent(event);
 			}

--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.cpp
@@ -342,7 +342,7 @@ void ScintillaEditBase::wheelEvent(QWheelEvent *event)
 				}
 				QQuickPaintedItem::wheelEvent(event);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#ifdef PLAT_QT_QML
                 update();
 #endif
 #else


### PR DESCRIPTION
Hello,

After switching from Qt 5 to Qt 6 I noticed that scrolling with the mouse wheel no longer works.
It seems like the bug occurs because of one incorrect "#if" (see changes).

You can recreate the bug using the QuickScintillaDemoApp.
After removing the "#if", scrolling works again.
